### PR TITLE
Bug Fix: JSON property text values/unpacking conditions only

### DIFF
--- a/src/parser/common.types.ts
+++ b/src/parser/common.types.ts
@@ -466,6 +466,7 @@ export class SQXPropertyRef extends SQXToken
         } else if ( typeof( raw ) === 'string' ) {
             instance.property = raw;
         }
+        instance.textValue = instance.ns ? `${instance.ns}:${instance.property}` : instance.property;
         return instance;
     }
 

--- a/src/parser/operator.types.ts
+++ b/src/parser/operator.types.ts
@@ -191,6 +191,8 @@ export class SQXComparatorEqual extends SQXOperatorBase
     public fromJson( raw:any, converter:any ) {
         this.property = converter( raw[0] );
         this.value = SQXScalarValue.fromJson( raw[1] );
+        this.opPropertyRef = new SQXPropertyRef( this.property.textValue );
+        this.opValues = [ this.value ];
     }
 
     public fromParser( cursor:SQXParseCursor, tokenIndex:number ) {
@@ -531,6 +533,8 @@ export class SQXComparatorIn extends SQXOperatorBase
         for ( let i = 0; i < raw[1].length; i++ ) {
             this.values.push( SQXScalarValue.fromJson( raw[1][i] ) );
         }
+        this.opPropertyRef = new SQXPropertyRef( this.property.textValue );
+        this.opValues = [ ...this.values ];
     }
 
     public fromParser( cursor:SQXParseCursor, tokenIndex:number, peers:SQXToken[], parameters:SQXToken[] ) {

--- a/src/parser/query.types.ts
+++ b/src/parser/query.types.ts
@@ -100,6 +100,15 @@ export class SQXSearchQuery
         item.limit             =   parsed.limit || null;
         item.having            =   parsed.having || null;
         item.time_range        =   parsed.time_range || null;
+        if ( item.where === null ) {
+            if ( parsed.hasOwnProperty("and") && parsed.and instanceof SQXOperatorAnd ) {
+                item.where = new SQXClauseWhere();
+                item.where.condition = parsed.and;
+            } else if ( parsed.hasOwnProperty("or") && parsed.or instanceof SQXOperatorOr ) {
+                item.where = new SQXClauseWhere();
+                item.where.condition = parsed.and;
+            }
+        }
 
         return item;
     }


### PR DESCRIPTION
- Added logic to detect orphaned conditional segments in
  SQXSearchQuery.fromJSON, and put them into an implicit WHERE clause
- Added logic to rehydrate textValue property for property references in
  fromJson conversion