### PR TITLE
Bug Fix: JSON property text values/unpacking conditions only

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export {
   ReadLogMessageResponse } from './search-client';
 
 export * from './parser';
+


### PR DESCRIPTION
- Added logic to detect orphaned conditional segments in
  SQXSearchQuery.fromJSON, and put them into an implicit WHERE clause
- Added logic to rehydrate textValue property for property references in
  fromJson conversion
- Added a newline to end Friday on a happy note