### PR TITLE
hardcode typescript version and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/search",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Search Public API",
   "author": {
@@ -55,7 +55,7 @@
     "sinon": "^8.1.1",
     "tslint": "^5.12.1",
     "tslint-config-airbnb": "^5.11.1",
-    "typescript": "^3.2.4",
+    "typescript": "~3.6.0",
     "webpack": "^4.29.0",
     "webpack-cli": "^3.2.1"
   },


### PR DESCRIPTION
I was getting ERROR in node_modules/@al/search/dist/typings/parser/common.types.d.ts(111,9): error TS1086: An accessor cannot be declared in an ambient context.

looks like typescript version was causing it